### PR TITLE
fix: ratelimit issues

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -29,4 +29,5 @@ const app = express()
     sirv("static", { dev }),
     sapper.middleware()
   )
+  .set('trust proxy', 1)
   .listen(PORT);


### PR DESCRIPTION
`express-rate-limit` is rate-limiting based on caddy as the client's IP which is incorrect.
See https://github.com/nfriedly/express-rate-limit#troubleshooting-proxy-issues.
